### PR TITLE
Fix import json to spork/json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # janet-pq
 Bindings to libpq.
 
+Uses `spork` as a dependency. Install with:
+
+```
+jpm install spork
+jpm install pq
+```
+
 # quick-examples
 
 Basic usage:

--- a/pq.janet
+++ b/pq.janet
@@ -1,5 +1,5 @@
 (import _pq)
-(import json)
+(import spork/json)
 
 #PQStatus
 (def CONNECTION_OK _pq/CONNECTION_OK)


### PR DESCRIPTION
Requires spork to be installed. Also add a note to readme.

Without this fix, `(import pq)` triggers an error. And there's no obvious way to satisfy the dependency `(import json)` as far as I'm aware.