### PR TITLE
Add decoder for timestamp without time zone

### DIFF
--- a/pq.janet
+++ b/pq.janet
@@ -50,6 +50,7 @@
     701 scan-number
     1042 identity
     1043 identity
+    1114 identity # timestamp without time zone, returned as "2017-12-09 21:00:00"
     1700 scan-number
     3802 json/decode
   })


### PR DESCRIPTION
Decoded as a simple string since Janet doesn't have a concept of a date in a standard library. Janet has a vague idea in the form of (os/date) but it includes several other things not conveyed by this PG format such as month-day, dst etc.